### PR TITLE
Adding profile for liantus5 to ZtM Job Board

### DIFF
--- a/Submissions/liantus5.json
+++ b/Submissions/liantus5.json
@@ -1,0 +1,16 @@
+{
+  "name": "Liana Giniatullina",
+  "img": "https://avatars.githubusercontent.com/u/87837396?v=4",
+  "email": "lianaginiat@gmail.com",
+  "links": {
+    "website": "https://lianaginiat.com/",
+    "linkedin": "https://www.linkedin.com/in/lianaginiat",
+    "github": "https://github.com/liantus5"
+  },
+  "jobTitle": "Software Engineer in Training",
+  "location": {
+    "city": "Los Angeles",
+    "state": "CA",
+    "country": "United States"
+  }
+} 


### PR DESCRIPTION
## Details

Adding `Submissions/liantus5.json` so my profile appears on the job board.

## Motivation

Following the instructions in the [ZtM-Job-Board README](https://github.com/zero-to-mastery/ZtM-Job-Board#how-to-add-your-name-to-the-list) to add my profile to the job board. 

## Testing

Ran

```
npm ci
npm start
```

Locally and verified my profile appears on the website locally, and that the links work as expected. No errors related to my change in the console. 

<img width="646" alt="Screen Shot 2022-03-05 at 7 20 33 PM" src="https://user-images.githubusercontent.com/87837396/156907802-854569a0-eea7-47e9-9529-e66b871cea54.png">

